### PR TITLE
Switch to aiohttp async search

### DIFF
--- a/alita_agent_prototype/alita_agent/config/settings.py
+++ b/alita_agent_prototype/alita_agent/config/settings.py
@@ -35,7 +35,7 @@ class AlitaConfig:
         self.planning.setdefault('max_react_steps', 10)
         self.mcp.setdefault('execution_timeout', 60)
         self.security.setdefault('sandbox_enabled', True)
-        self.security.setdefault('allowed_imports', ['json', 'requests', 'math', 'random'])
+        self.security.setdefault('allowed_imports', ['json', 'aiohttp', 'math', 'random'])
 
     def get_workspace_path(self, sub_dir: str) -> Path:
         """Returns the absolute path to a subdirectory in the workspace."""

--- a/alita_agent_prototype/requirements.txt
+++ b/alita_agent_prototype/requirements.txt
@@ -1,7 +1,6 @@
 # Core async and web libraries
 asyncio>=3.4.3
 aiohttp>=3.8.0
-requests>=2.28.0
 beautifulsoup4>=4.11.0
 
 

--- a/alita_agent_prototype/tests/test_web_agent.py
+++ b/alita_agent_prototype/tests/test_web_agent.py
@@ -1,0 +1,34 @@
+def test_web_agent_search_async():
+    import asyncio
+    from unittest.mock import patch
+    from alita_agent.config.settings import AlitaConfig
+    from alita_agent.core.web_agent import WebAgent
+
+    config = AlitaConfig()
+    agent = WebAgent(config)
+
+    mock_json = {"RelatedTopics": [{"Text": "Example Result", "FirstURL": "http://example.com"}]}
+
+    class MockResponse:
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+        async def json(self):
+            return mock_json
+
+    class MockSession:
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+        def get(self, *args, **kwargs):
+            return MockResponse()
+
+    async def run():
+        with patch('aiohttp.ClientSession', return_value=MockSession()):
+            result = await agent.search("example")
+        assert result.query == "example"
+        assert result.results[0]['url'] == "http://example.com"
+
+    asyncio.run(run())

--- a/plan.md
+++ b/plan.md
@@ -9,7 +9,7 @@ Of course. You've provided a phenomenal deep-dive into the philosophy and archit
 | ALITA Component | Concrete Implementation | Notes |
 | :--- | :--- | :--- |
 | **Manager Agent** | **Orchestrator Core (`manager.py`)** | A Python class that runs the main ReAct loop. It contains the primary LLM, manages the task state, and decides which subsystem to call next. This is the brain. |
-| **Web Agent** | **Information Retrieval Service** | A set of functions for external lookups: `google_search()`, `github_search()`, and a `web_scraper()` using `requests` and `BeautifulSoup`. |
+| **Web Agent** | **Information Retrieval Service** | A set of asynchronous lookup functions: `google_search()`, `github_search()`, and a `web_scraper()` using `aiohttp` and `BeautifulSoup`. |
 | **MCP Box** | **Vector Database (`mcp_store.py`)** | A local vector store (ChromaDB/FAISS) where each MCP is an object. The `description` field is vectorized for semantic search. This is the agent's long-term capability memory. |
 | **Tool Creation** | **Toolsmith Module (`toolsmith.py`)** | A factory that takes a tool description, prompts a powerful LLM to generate Python code, and then calls the sandbox to test and validate it. |
 | **Tool Execution** | **Sandbox Executor (`sandbox.py`)** | A security-critical module that runs arbitrary Python code inside a heavily restricted **Docker container** (`--network=none`, resource limits). |
@@ -235,7 +235,6 @@ classifiers = [
 # Core async and web libraries
 asyncio>=3.4.3
 aiohttp>=3.8.0
-requests>=2.28.0
 beautifulsoup4>=4.11.0
 
 # Optional API clients (install as needed)
@@ -492,7 +491,7 @@ class AlitaConfig:
         self.planning.setdefault('max_react_steps', 10)
         self.mcp.setdefault('execution_timeout', 60)
         self.security.setdefault('sandbox_enabled', True)
-        self.security.setdefault('allowed_imports', ['json', 'requests', 'math', 'random'])
+        self.security.setdefault('allowed_imports', ['json', 'aiohttp', 'math', 'random'])
 
     def get_workspace_path(self, sub_dir: str) -> Path:
         """Returns the absolute path to a subdirectory in the workspace."""


### PR DESCRIPTION
## Summary
- implement asynchronous DuckDuckGo search using `aiohttp`
- remove `requests` dependency
- allow `aiohttp` in config security list
- update planning docs for new dependency
- add async WebAgent test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68482bab1ab08328831917d54c22ddd9