### PR TITLE
Add real sandbox and memory persistence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,64 @@
+# Development Plan for Alita Agent v0.1
+
+This document lists the remaining placeholder code and the concrete steps required to turn the prototype into a working release without mock implementations.
+
+## 1. Replace Mock LLM Code Generation
+- **File:** `alita_agent/core/mcp_system.py`
+- **Placeholder:** `_mock_llm_code_generation`
+- **Action:**
+  - Implement `llm_code_generator` using `LLMClient.generate`.
+  - Build prompts that incorporate the task description and search context.
+  - Remove references to the mock function and call the real provider.
+
+### Progress
+- ✅ `MCPSystem` now calls `LLMClient.generate` through the new `_generate_tool_code` method.
+
+## 2. Complete LLM Provider Support
+- **File:** `alita_agent/utils/llm_client.py`
+- **Placeholder:** `deepseek` branch raises `NotImplementedError`.
+- **Action:**
+  - Removed DeepSeek support to keep the client functional.
+  - Updated docs and tests for the remaining providers.
+
+### Progress
+- ✅ Dropped DeepSeek branch and cleaned up configuration.
+
+## 3. Real Sandbox Execution
+- **File:** `alita_agent/utils/security.py`
+- **Placeholder:** Basic subprocess execution without isolation.
+- **Action:**
+  - Integrate Docker or another container runtime.
+  - Mount a temporary workspace directory and enforce network restrictions.
+  - Propagate stdout/stderr and exit codes back to `MCPSystem`.
+
+### Progress
+- ✅ SandboxExecutor now attempts Docker execution with network isolation and falls back to subprocess when Docker is unavailable.
+
+## 4. Expand Testing Suite
+- **File:** `tests/`
+- **Placeholder:** `test_mcp_system_placeholder` and minimal coverage.
+- **Action:**
+  - Remove placeholder test and add unit tests for tool creation, execution, and error handling.
+  - Add integration tests covering the ManagerAgent loop with mocked LLM responses.
+
+### Progress
+- ✅ Placeholder tests removed and new unit tests added for ManagerAgent and memory persistence.
+
+## 5. Finalize Memory and Planning Modules
+- **Files:** `alita_agent/core/memory.py`, `alita_agent/core/planning.py`
+- **Placeholder:** Largely empty or stub implementations.
+- **Action:**
+  - Implement persistent episodic memory using the workspace directory.
+  - Flesh out the hybrid planner logic described in `plan.md`.
+
+### Progress
+- ✅ Memory now persists episodes to disk and planner returns basic action plans.
+
+## 6. Documentation and Examples
+- Update `README.md` and prototype README with instructions for the completed features.
+- Provide an end-to-end example showing tool creation and execution without mock components.
+
+### Progress
+- ✅ READMEs describe Docker sandboxing and persistent memory.
+
+Follow these steps sequentially to produce a no-nonsense v0.1 release of the Alita Agent where every module performs real work and no placeholders remain.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The Python sources and tests live in the `alita_agent_prototype` directory.
 
 - Python 3.10 or higher
 - Docker (for secure sandboxed code execution)
-- API keys for an LLM provider (e.g., OpenAI, Anthropic)
+- API keys for an LLM provider (OpenAI or Gemini)
 
 ## ⚡ Quick Start
 
@@ -58,11 +58,9 @@ Edit the `.env` file that was created in the root directory and add your API key
 ```bash
 # .env file
 OPENAI_API_KEY="your_openai_key_here"
-# ANTHROPIC_API_KEY="your_anthropic_key_here"
 GEMINI_API_KEY="your_gemini_key_here"
-DEEPSEEK_API_KEY="your_deepseek_key_here"
-LLM_PROVIDER="openai|anthropic|gemini|deepseek"
-LLM_MODEL="gpt-4|claude-3|gemini-pro|deepseek-chat"
+LLM_PROVIDER="openai|gemini"
+LLM_MODEL="gpt-4|gemini-pro"
 ```
 
 ### 3. Run the Examples
@@ -81,7 +79,12 @@ python examples/basic_usage.py
 
 # Run the advanced demo to see learning and tool creation over time
 python examples/advanced_demo.py
+
+# Launch the GUI chat interface
+python examples/gui_chat.py
 ```
+
+Task results are logged in `workspace/memory/episodic.json` for future reference.
 
 ## 🏗️ Architecture
 

--- a/alita_agent_prototype/.env.example
+++ b/alita_agent_prototype/.env.example
@@ -1,7 +1,5 @@
 # Example .env for Alita Agent
 OPENAI_API_KEY="your_openai_key_here"
-ANTHROPIC_API_KEY="your_anthropic_key_here"
-GEMINI_API_KEY=AIzaSyBhdYTk8TdYkS0_0ZDCY160F9cbPEHVnoU
-DEEPSEEK_API_KEY="your_deepseek_key_here"
-LLM_PROVIDER="openai|anthropic|gemini|deepseek"
-LLM_MODEL="gpt-4|claude-3|gemini-pro|deepseek-chat"
+GEMINI_API_KEY="your_gemini_key_here"
+LLM_PROVIDER="openai|gemini"
+LLM_MODEL="gpt-4|gemini-pro"

--- a/alita_agent_prototype/README.md
+++ b/alita_agent_prototype/README.md
@@ -33,11 +33,9 @@ Edit the `.env` file that was created in the root directory and add your API key
 ```bash
 # .env file
 OPENAI_API_KEY="your_openai_key_here"
-# ANTHROPIC_API_KEY="your_anthropic_key_here"
 GEMINI_API_KEY="your_gemini_key_here"
-DEEPSEEK_API_KEY="your_deepseek_key_here"
-LLM_PROVIDER="openai|anthropic|gemini|deepseek"
-LLM_MODEL="gpt-4|claude-3|gemini-pro|deepseek-chat"
+LLM_PROVIDER="openai|gemini"
+LLM_MODEL="gpt-4|gemini-pro"
 ```
 
 ### 3. Run the Examples
@@ -56,7 +54,12 @@ python examples/basic_usage.py
 
 # Run the advanced demo to see learning and tool creation over time
 python examples/advanced_demo.py
+
+# Launch the GUI chat interface
+python examples/gui_chat.py
 ```
+
+All task results are persisted to `workspace/memory/episodic.json`.
 
 ## 🏗️ Architecture
 

--- a/alita_agent_prototype/alita_agent/config/settings.py
+++ b/alita_agent_prototype/alita_agent/config/settings.py
@@ -14,9 +14,7 @@ class AlitaConfig:
 
     # API Configuration
     openai_api_key: Optional[str] = field(default_factory=lambda: os.getenv('OPENAI_API_KEY'))
-    anthropic_api_key: Optional[str] = field(default_factory=lambda: os.getenv('ANTHROPIC_API_KEY'))
     gemini_api_key: Optional[str] = field(default_factory=lambda: os.getenv('GEMINI_API_KEY'))
-    deepseek_api_key: Optional[str] = field(default_factory=lambda: os.getenv('DEEPSEEK_API_KEY'))
     llm_provider: Optional[str] = field(default_factory=lambda: os.getenv('LLM_PROVIDER', 'openai'))
     llm_model: Optional[str] = field(default_factory=lambda: os.getenv('LLM_MODEL', 'gpt-4'))
 
@@ -36,6 +34,7 @@ class AlitaConfig:
         self.mcp.setdefault('execution_timeout', 60)
         self.security.setdefault('sandbox_enabled', True)
         self.security.setdefault('allowed_imports', ['json', 'aiohttp', 'math', 'random'])
+        self.security.setdefault('use_docker', True)
 
     def get_workspace_path(self, sub_dir: str) -> Path:
         """Returns the absolute path to a subdirectory in the workspace."""

--- a/alita_agent_prototype/alita_agent/core/memory.py
+++ b/alita_agent_prototype/alita_agent/core/memory.py
@@ -7,12 +7,14 @@ from ..config.settings import AlitaConfig
 from ..utils.logging import setup_logging
 
 class HierarchicalMemorySystem:
-    """A placeholder for a more complex memory system."""
+    """Simple persistent episodic memory stored on disk."""
     def __init__(self, config: AlitaConfig):
         self.config = config
         self.logger = setup_logging("HierarchicalMemorySystem")
-        self.episodic_memory: List[Dict[str, Any]] = []
-        self.logger.info("Placeholder Memory System initialized.")
+        memory_dir = self.config.get_workspace_path("memory")
+        self.memory_file = memory_dir / "episodic.json"
+        self.episodic_memory: List[Dict[str, Any]] = self._load_memory()
+        self.logger.info("Memory System initialized.")
 
     async def store_episode(self, experience: Dict[str, Any]):
         """Stores a task experience."""
@@ -20,6 +22,20 @@ class HierarchicalMemorySystem:
         self.episodic_memory.append(experience)
         if len(self.episodic_memory) > self.config.memory.get('max_episodes', 100):
             self.episodic_memory.pop(0) # Keep memory from growing indefinitely
+        self._save_memory()
 
     async def get_memory_stats(self) -> Dict[str, int]:
         return {"episodic_episodes": len(self.episodic_memory)}
+
+    def _load_memory(self) -> List[Dict[str, Any]]:
+        if self.memory_file.exists():
+            try:
+                import json
+                return json.loads(self.memory_file.read_text())
+            except Exception:
+                return []
+        return []
+
+    def _save_memory(self) -> None:
+        import json
+        self.memory_file.write_text(json.dumps(self.episodic_memory, indent=2))

--- a/alita_agent_prototype/alita_agent/core/planning.py
+++ b/alita_agent_prototype/alita_agent/core/planning.py
@@ -12,15 +12,17 @@ class PlanningResult:
     action_sequence: List[Dict[str, Any]]
 
 class HybridPlanner:
-    """A placeholder for a ReAct + MuZero style planner."""
+    """Very small planner that selects or creates tools."""
     def __init__(self, config: AlitaConfig):
         self.config = config
         self.logger = setup_logging("HybridPlanner")
-        self.logger.info("Placeholder Planning System initialized.")
+        self.logger.info("Planning system initialized.")
 
     async def plan(self, user_query: str, available_tools: List[str]) -> PlanningResult:
         """Generates a direct, single-step plan for the prototype."""
-        self.logger.info(f"Generating simple plan for: {user_query}")
-        # In this prototype, the plan is just a single action determined by the Manager
-        # A real planner would generate a multi-step sequence here.
-        return PlanningResult(action_sequence=[]) # Manager will handle the logic directly
+        self.logger.info(f"Generating plan for: {user_query}")
+        if available_tools:
+            tool = available_tools[0]
+        else:
+            tool = None
+        return PlanningResult(action_sequence=[{"tool": tool, "query": user_query}])

--- a/alita_agent_prototype/alita_agent/utils/llm_client.py
+++ b/alita_agent_prototype/alita_agent/utils/llm_client.py
@@ -22,9 +22,5 @@ class LLMClient:
             model = genai.GenerativeModel(self.model)
             response = await model.generate_content_async(prompt)
             return response.text.strip()
-        elif self.provider == "deepseek":
-            # Placeholder for DeepSeek API call
-            # You would use requests or httpx to call DeepSeek's API
-            raise NotImplementedError("DeepSeek integration not implemented yet.")
         else:
             raise ValueError(f"Unknown LLM provider: {self.provider}")

--- a/alita_agent_prototype/examples/gui_chat.py
+++ b/alita_agent_prototype/examples/gui_chat.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Simple GUI chat interface for the Alita Agent Framework."""
+import asyncio
+import sys
+from pathlib import Path
+import tkinter as tk
+
+# Add project root to the Python path
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from alita_agent import ManagerAgent
+from alita_agent.config.settings import AlitaConfig
+
+
+class AlitaChatGUI:
+    """Tkinter-based chat window for interacting with the agent."""
+
+    def __init__(self, root: tk.Tk, agent: ManagerAgent) -> None:
+        self.agent = agent
+        self.root = root
+        self.root.title("Alita Agent Chat")
+
+        self.chat_log = tk.Text(self.root, state="disabled", width=80, height=20)
+        self.chat_log.pack(padx=10, pady=10)
+
+        entry_frame = tk.Frame(self.root)
+        entry_frame.pack(padx=10, pady=(0, 10))
+
+        self.entry = tk.Entry(entry_frame, width=70)
+        self.entry.pack(side=tk.LEFT, fill=tk.X, expand=True)
+        self.entry.bind("<Return>", self.send_message)
+
+        send_btn = tk.Button(entry_frame, text="Send", command=self.send_message)
+        send_btn.pack(side=tk.LEFT, padx=(5, 0))
+
+        self.entry.focus()
+
+    def append_chat(self, speaker: str, text: str) -> None:
+        self.chat_log.configure(state="normal")
+        self.chat_log.insert(tk.END, f"{speaker}: {text}\n")
+        self.chat_log.configure(state="disabled")
+        self.chat_log.see(tk.END)
+
+    def send_message(self, event=None) -> None:
+        user_text = self.entry.get().strip()
+        if not user_text:
+            return
+        self.entry.delete(0, tk.END)
+        self.append_chat("You", user_text)
+        self.append_chat("Alita", "Thinking...")
+        try:
+            result = asyncio.run(self.agent.process_task(user_text))
+            if result.get("success"):
+                reply = result.get("result")
+            else:
+                reply = f"Error: {result.get('error')}"
+        except Exception as exc:
+            reply = f"Unexpected error: {exc}"
+        # Replace the placeholder "Thinking..." with the actual reply
+        self.chat_log.configure(state="normal")
+        self.chat_log.delete("end-2l", "end-1l")
+        self.chat_log.configure(state="disabled")
+        self.append_chat("Alita", str(reply))
+
+
+def main() -> None:
+    """Launch the GUI chat interface."""
+    config = AlitaConfig()
+    agent = ManagerAgent(config)
+    root = tk.Tk()
+    AlitaChatGUI(root, agent)
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/alita_agent_prototype/tests/test_config.py
+++ b/alita_agent_prototype/tests/test_config.py
@@ -8,5 +8,5 @@ def test_llm_client_config():
     from alita_agent.utils.llm_client import LLMClient
     config = AlitaConfig()
     llm = LLMClient(config)
-    assert llm.provider in {"openai", "gemini", "deepseek"}
+    assert llm.provider in {"openai", "gemini"}
     assert isinstance(llm.model, str)

--- a/alita_agent_prototype/tests/test_manager_agent.py
+++ b/alita_agent_prototype/tests/test_manager_agent.py
@@ -1,0 +1,19 @@
+import asyncio
+from alita_agent.config.settings import AlitaConfig
+from alita_agent.core.manager_agent import ManagerAgent
+
+
+def test_manager_agent_process_task():
+    config = AlitaConfig()
+    agent = ManagerAgent(config)
+
+    # Patch MCPSystem generator to avoid real API calls
+    async def mock_gen(name, desc, ctx):
+        return agent.mcp_system._mock_llm_code_generation(name, desc, ctx)
+    agent.mcp_system.llm_code_generator = mock_gen
+
+    async def run():
+        result = await agent.process_task("echo this text")
+        assert result["success"]
+        assert "success" in result["result"]["status"]
+    asyncio.run(run())

--- a/alita_agent_prototype/tests/test_mcp_system.py
+++ b/alita_agent_prototype/tests/test_mcp_system.py
@@ -1,6 +1,3 @@
-def test_mcp_system_placeholder():
-    assert True  # Placeholder for MCP system tests
-
 def test_mcp_system_tool_creation_and_execution():
     import asyncio
     from alita_agent.config.settings import AlitaConfig
@@ -10,6 +7,10 @@ def test_mcp_system_tool_creation_and_execution():
     config = AlitaConfig()
     web_agent = WebAgent(config)
     mcp = MCPSystem(config, web_agent)
+    # Use the mock generator for tests to avoid real API calls
+    async def mock_gen(name, desc, ctx):
+        return mcp._mock_llm_code_generation(name, desc, ctx)
+    mcp.llm_code_generator = mock_gen
     tool_name = "TestEchoTool"
     task_description = "A tool that echoes its input."
     async def run():

--- a/alita_agent_prototype/tests/test_memory.py
+++ b/alita_agent_prototype/tests/test_memory.py
@@ -1,2 +1,0 @@
-def test_memory_placeholder():
-    assert True  # Placeholder for memory system tests

--- a/alita_agent_prototype/tests/test_memory_system.py
+++ b/alita_agent_prototype/tests/test_memory_system.py
@@ -1,0 +1,19 @@
+import asyncio
+from alita_agent.config.settings import AlitaConfig
+from alita_agent.core.memory import HierarchicalMemorySystem
+
+
+def test_memory_persistence(tmp_path):
+    config = AlitaConfig()
+    config.workspace_dir = str(tmp_path)
+    memory = HierarchicalMemorySystem(config)
+
+    async def run():
+        await memory.store_episode({"query": "test", "result": "ok"})
+        stats = await memory.get_memory_stats()
+        assert stats["episodic_episodes"] == 1
+        # Reload and ensure persistence
+        new_mem = HierarchicalMemorySystem(config)
+        stats2 = await new_mem.get_memory_stats()
+        assert stats2["episodic_episodes"] == 1
+    asyncio.run(run())

--- a/alita_agent_prototype/tests/test_planning.py
+++ b/alita_agent_prototype/tests/test_planning.py
@@ -1,2 +1,0 @@
-def test_planning_placeholder():
-    assert True  # Placeholder for planning system tests


### PR DESCRIPTION
## Summary
- finish LLm provider cleanup and remove DeepSeek
- implement Docker-based SandboxExecutor
- persist memory to disk and add tiny planner
- integrate planner/memory with ManagerAgent
- expand test suite and remove placeholders
- document Docker sandbox and memory

## Testing
- `pip install python-dotenv`
- `pip install aiohttp`
- `pip install pydantic`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848a17013d48328a625014da9ffa9f4