### PR TITLE
Cleanup docs and fix lint warnings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,9 +17,6 @@ This document lists the remaining placeholder code and the concrete steps requir
 - ✅ `MCPSystem` now calls `LLMClient.generate` through the new `_generate_tool_code` method.
 
 
-### Progress
-- ✅ `MCPSystem` now calls `LLMClient.generate` through the new `_generate_tool_code` method.
-
 ## 2. Complete LLM Provider Support
 - **File:** `alita_agent/utils/llm_client.py`
 - **Placeholder:** `deepseek` branch raises `NotImplementedError`.
@@ -51,21 +48,8 @@ This document lists the remaining placeholder code and the concrete steps requir
   - Mount a temporary workspace directory and enforce network restrictions.
   - Propagate stdout/stderr and exit codes back to `MCPSystem`.
 
-
 ### Progress
 - ✅ SandboxExecutor now attempts Docker execution with network isolation and falls back to subprocess when Docker is unavailable.
-
-=======
-
-### Progress
-- ✅ SandboxExecutor now attempts Docker execution with network isolation and falls back to subprocess when Docker is unavailable.
-
-=======
-
-### Progress
-- ✅ SandboxExecutor now attempts Docker execution with network isolation and falls back to subprocess when Docker is unavailable.
-
-
 
 ## 4. Expand Testing Suite
 - **File:** `tests/`
@@ -101,13 +85,6 @@ This document lists the remaining placeholder code and the concrete steps requir
 ## 7. Interactive Configuration
 - **File:** `alita_agent/config/settings.py`
 - **Feature:** Prompt the user for missing LLM provider, model, and API keys on first run and persist them to `.env`.
-
 ### Progress
 - ✅ Config now saves credentials interactively when missing.
-
-
-### Progress
-- ✅ READMEs describe Docker sandboxing and persistent memory.
-- 
-
 Follow these steps sequentially to produce a no-nonsense v0.1 release of the Alita Agent where every module performs real work and no placeholders remain.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-
-
 # Alita Agent
 
 This repository contains the prototype of the Alita agent framework. The working code lives inside the `alita_agent_prototype` directory.

--- a/alita/alita_agent_prototype/install.py
+++ b/alita/alita_agent_prototype/install.py
@@ -2,10 +2,8 @@
 Cross-platform installer for the Alita Agent Framework.
 Creates a virtual environment, installs dependencies, and sets up the .env file.
 """
-import os
 import subprocess
 import sys
-import venv
 from pathlib import Path
 
 ROOT_DIR = Path(__file__).parent
@@ -34,10 +32,8 @@ def main():
 
     # 2. Determine Python and Pip executables
     if sys.platform == "win32":
-        python_executable = VENV_DIR / "Scripts" / "python.exe"
         pip_executable = VENV_DIR / "Scripts" / "pip.exe"
     else:
-        python_executable = VENV_DIR / "bin" / "python"
         pip_executable = VENV_DIR / "bin" / "pip"
 
     # 3. Install dependencies

--- a/alita_agent_prototype/alita_agent/config/settings.py
+++ b/alita_agent_prototype/alita_agent/config/settings.py
@@ -1,6 +1,6 @@
 """Configuration settings for the Alita Agent Framework."""
 import os
-from typing import Dict, Any, Optional, List
+from typing import Dict, Any, Optional
 from pathlib import Path
 from dataclasses import dataclass, field
 import sys

--- a/alita_agent_prototype/alita_agent/core/manager_agent.py
+++ b/alita_agent_prototype/alita_agent/core/manager_agent.py
@@ -24,7 +24,7 @@ class ManagerAgent:
     async def process_task(self, user_query: str) -> Dict[str, Any]:
         self.logger.info(f"Received task: '{user_query}'")
         try:
-            plan = await self.planner.plan(user_query, [])
+            await self.planner.plan(user_query, [])
             # 1. Determine the name and description of the required tool
             tool_name = self._generate_tool_name_from_query(user_query)
             tool_description = f"A tool that can: {user_query}"

--- a/alita_agent_prototype/alita_agent/core/mcp_system.py
+++ b/alita_agent_prototype/alita_agent/core/mcp_system.py
@@ -1,8 +1,7 @@
 
 """The MCP System: Handles dynamic tool creation, validation, and execution."""
 import json
-from pathlib import Path
-from typing import Dict, Any, Optional
+from typing import Dict, Any
 from ..config.settings import AlitaConfig
 from ..utils.logging import setup_logging
 from ..exceptions import ToolCreationError

--- a/alita_agent_prototype/alita_agent/utils/llm_client.py
+++ b/alita_agent_prototype/alita_agent/utils/llm_client.py
@@ -1,5 +1,4 @@
-import os
-from typing import Optional
+
 
 class LLMClient:
     def __init__(self, config):

--- a/alita_agent_prototype/install.py
+++ b/alita_agent_prototype/install.py
@@ -2,10 +2,8 @@
 Cross-platform installer for the Alita Agent Framework.
 Creates a virtual environment, installs dependencies, and sets up the .env file.
 """
-import os
 import subprocess
 import sys
-import venv
 from pathlib import Path
 
 ROOT_DIR = Path(__file__).parent
@@ -34,10 +32,8 @@ def main():
 
     # 2. Determine Python and Pip executables
     if sys.platform == "win32":
-        python_executable = VENV_DIR / "Scripts" / "python.exe"
         pip_executable = VENV_DIR / "Scripts" / "pip.exe"
     else:
-        python_executable = VENV_DIR / "bin" / "python"
         pip_executable = VENV_DIR / "bin" / "pip"
 
     # 3. Install dependencies


### PR DESCRIPTION
## Summary
- remove stray merge markers
- tidy up README formatting
- drop unused imports
- clean up installer scripts
- delete unused variable in ManagerAgent

## Testing
- `ruff check .`
- `pytest -q` *(fails: The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_684b0a7aa6388328aad6ff4b9a7c3c20