### PR TITLE
Add documentation folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,3 +108,7 @@ To run the test suite, use `pytest`:
 
 
 For full documentation and advanced usage, see [alita_agent_prototype/README.md](alita_agent_prototype/README.md).
+
+## 📚 Additional Documentation
+
+The `docs/` directory contains extended guides on architecture, setup, and usage examples. Start with [docs/overview.md](docs/overview.md) for a high-level look at the project.

--- a/alita_agent_prototype/tests/test_manager_agent.py
+++ b/alita_agent_prototype/tests/test_manager_agent.py
@@ -3,16 +3,11 @@ from alita_agent.config.settings import AlitaConfig
 from alita_agent.core.manager_agent import ManagerAgent
 
 
-
-
 def test_manager_agent_process_task(tmp_path):
     config = AlitaConfig(workspace_dir=str(tmp_path))
     manager = ManagerAgent(config)
 
     async def mock_gen(name, desc, ctx):
-=======
-    async def mock_gen(name, desc) 
-
         return f"""#!/usr/bin/env python3
 import sys
 import json
@@ -33,11 +28,6 @@ if __name__ == '__main__':
     else:
         print('This script should be run with JSON input via stdin.')
 """
- 
-=======
-=======
-        return manager.mcp_system._mock_llm_code_generation(name, desc, ctx)
-
 
     manager.mcp_system.llm_code_generator = mock_gen
 
@@ -50,6 +40,7 @@ if __name__ == '__main__':
         assert tool_file.exists()
 
     asyncio.run(run())
+
 
 def test_manager_agent_process_task_default():
     config = AlitaConfig()
@@ -84,4 +75,3 @@ if __name__ == '__main__':
         assert result["success"]
         assert "success" in result["result"]["status"]
     asyncio.run(run())
-

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,11 @@
+# Architecture
+
+Alita Agent is organized around a small set of cooperating modules:
+
+- **ManagerAgent** – Orchestrates tasks, selects or creates tools, and drives the overall ReAct loop.
+- **WebAgent** – Performs internet searches and GitHub lookups to gather reference material for new tools.
+- **MCP System** – Generates, tests, and registers tools in a sandboxed environment.
+- **Memory System** – Persists episodic experiences and tool metadata in the workspace.
+- **Planner** – Uses ReAct-style reasoning to evaluate and select actions during a task.
+
+The ManagerAgent interacts with these components to continuously expand the agent's capabilities. Generated tools live inside the `workspace/tools` directory and can be called in future tasks.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,12 @@
+# Example Usage
+
+The `alita_agent_prototype/examples` folder contains several demonstrations of the framework.
+
+## `basic_usage.py`
+Runs a simple task to show how the ManagerAgent coordinates tool creation and execution.
+
+## `advanced_demo.py`
+Showcases learning over multiple iterations as the system builds new tools and reuses them.
+
+## `gui_chat.py`
+Launches a minimal graphical chat interface for interactive experiments.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,0 +1,35 @@
+# Getting Started
+
+Follow these steps to configure Alita Agent and run the example scripts.
+
+## 1. Install Dependencies
+
+```bash
+python alita_agent_prototype/install.py
+```
+
+This script creates a virtual environment in `.venv`, installs all required packages, and writes a `.env` file if one does not exist.
+
+## 2. Configure API Keys
+
+Edit the generated `.env` file and add credentials for your preferred LLM provider:
+
+```bash
+OPENAI_API_KEY="your_openai_key_here"
+GEMINI_API_KEY="your_gemini_key_here"
+LLM_PROVIDER="gemini"
+LLM_MODEL="gemini-pro"
+```
+
+If you omit these values, the system will prompt for them on first run and save them automatically.
+
+## 3. Run Examples
+
+Activate the environment and launch one of the example scripts:
+
+```bash
+source .venv/bin/activate
+python examples/basic_usage.py
+```
+
+See `docs/examples.md` for more details about available demos.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,11 @@
+# Project Overview
+
+Alita Agent is a self-evolving AI framework that focuses on dynamic tool creation and autonomous task execution. It pairs a ManagerAgent with a WebAgent to plan, research, and build new capabilities on the fly.
+
+Key features include:
+
+- **Self-Evolving Architecture**: Generates and refines tools as needed for a given task.
+- **Modular Design**: Components for memory, planning, and secure sandbox execution keep responsibilities separated.
+- **LLM Agnostic**: Supports multiple providers via a simple configuration layer.
+
+See the rest of the documentation in this folder for setup instructions and deeper technical details.


### PR DESCRIPTION
## Summary
- add an initial `docs/` directory with project overview and guides
- link new docs from the README
- fix stray conflict markers in `test_manager_agent.py`

## Testing
- `pip install -e alita_agent_prototype`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bb152a5608328bb3be1aee9397eaf