### PR TITLE
Fix proxy URL retrieval in automation commands

### DIFF
--- a/cortex-extension/src/commands/automation.ts
+++ b/cortex-extension/src/commands/automation.ts
@@ -15,7 +15,7 @@ const post = async (url: string, body?: any): Promise<any> =>
   });
 
 export function registerAutomationCommands(ctx: vscode.ExtensionContext) {
-  const base = cfg<string>('cortex.proxyUrl', 'http://localhost:8000');
+  const base = cfg<string>('proxyUrl', 'http://localhost:8000');
 
   const runPy = vscode.commands.registerCommand('cortex.runPythonTests', async () => {
     try {


### PR DESCRIPTION
## Summary
- Fix Cortex VSCode extension automation commands to read `proxyUrl` setting correctly

## Testing
- `npm run compile`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7f284721c8328b59accf88155f627