### PR TITLE
fix: suppress import order warnings in examples

### DIFF
--- a/alita_agent_prototype/demo_working.py
+++ b/alita_agent_prototype/demo_working.py
@@ -10,9 +10,10 @@ from pathlib import Path
 # Add project root to path
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from alita_agent import ManagerAgent
-from alita_agent.config.settings import AlitaConfig
-from alita_agent.core.web_agent import SearchResult
+from alita_agent import ManagerAgent  # noqa: E402
+from alita_agent.config.settings import AlitaConfig  # noqa: E402
+from alita_agent.core.web_agent import SearchResult  # noqa: E402
+
 
 async def demo_framework():
     """Demonstrate the Alita framework working end-to-end."""
@@ -29,9 +30,16 @@ async def demo_framework():
 
     # 3. Mock external dependencies for demo
     async def mock_search(query):
-        return SearchResult(query=query, results=[
-            {"title": "Python String Reversal", "snippet": "Simple string reversal in Python"}
-        ])
+        return SearchResult(
+            query=query,
+            results=[
+                {
+                    "title": "Python String Reversal",
+                    "snippet": "Simple string reversal in Python",
+                }
+            ],
+        )
+
     manager.mcp_system.web_agent.search = mock_search
 
     # 4. Mock LLM code generation for demo
@@ -73,20 +81,22 @@ if __name__ == '__main__':
     except Exception as e:
         print(json.dumps({{"error": str(e)}}))
 """
+
     manager.mcp_system.llm_code_generator = mock_code_generator
 
     # 5. Process a sample task
     task_query = "Create a tool to reverse a given string"
     print(f"\n▶️  Processing task: '{task_query}'")
-    
+
     try:
         result = await manager.process_task(task_query)
-        
+
         print("\n--- Task Result ---")
         if result.get("success"):
             print("✅ Success!")
             print("📦 Tool Creation Result:")
             import json
+
             print(json.dumps(result.get("result"), indent=2))
         else:
             print("❌ Failure!")
@@ -96,8 +106,10 @@ if __name__ == '__main__':
         # 6. Test the created tool with actual input
         print("\n▶️  Testing the created tool with sample input...")
         tool_name = manager._generate_tool_name_from_query(task_query)
-        test_result = await manager.mcp_system.execute_tool(tool_name, {"text": "Hello World"})
-        
+        test_result = await manager.mcp_system.execute_tool(
+            tool_name, {"text": "Hello World"}
+        )
+
         if test_result.success:
             print("✅ Tool execution successful!")
             print("📦 Tool Execution Result:")
@@ -108,11 +120,11 @@ if __name__ == '__main__':
 
     except Exception as e:
         print(f"\n💥 An error occurred: {e}")
-    
+
     # 7. Show memory stats
     memory_stats = await manager.memory.get_memory_stats()
     print(f"\n📊 Memory Stats: {memory_stats}")
-    
+
     # 8. Check workspace
     tools_dir = config.get_workspace_path("tools")
     print(f"\n📁 Created tools in: {tools_dir}")
@@ -121,8 +133,9 @@ if __name__ == '__main__':
         print(f"   Found {len(tool_files)} tool files:")
         for tool_file in tool_files:
             print(f"   - {tool_file.name}")
-    
+
     print("\n🎉 Demo completed successfully!")
+
 
 if __name__ == "__main__":
     asyncio.run(demo_framework())

--- a/alita_agent_prototype/examples/basic_usage.py
+++ b/alita_agent_prototype/examples/basic_usage.py
@@ -1,4 +1,3 @@
-
 #!/usr/bin/env python3
 """
 Basic usage example for the Alita Agent Framework.
@@ -11,8 +10,9 @@ from pathlib import Path
 # Add project root to the Python path
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from alita_agent import ManagerAgent
-from alita_agent.config.settings import AlitaConfig
+from alita_agent import ManagerAgent  # noqa: E402
+from alita_agent.config.settings import AlitaConfig  # noqa: E402
+
 
 async def main():
     """Main example function."""
@@ -42,6 +42,7 @@ async def main():
             print("✅ Success!")
             print("📦 Result Payload:")
             import json
+
             print(json.dumps(result.get("result"), indent=2))
         else:
             print("❌ Failure!")
@@ -50,8 +51,11 @@ async def main():
 
     except Exception as e:
         print(f"\n💥 An unexpected error occurred during the demonstration: {e}")
-    
-    print("🎉 Basic usage example completed. Check the 'workspace/tools' directory for any new tools created.")
+
+    print(
+        "🎉 Basic usage example completed. Check the 'workspace/tools' directory for any new tools created."
+    )
+
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/alita_agent_prototype/examples/gui_chat.py
+++ b/alita_agent_prototype/examples/gui_chat.py
@@ -8,8 +8,8 @@ import tkinter as tk
 # Add project root to the Python path
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from alita_agent import ManagerAgent
-from alita_agent.config.settings import AlitaConfig
+from alita_agent import ManagerAgent  # noqa: E402
+from alita_agent.config.settings import AlitaConfig  # noqa: E402
 
 
 class AlitaChatGUI:


### PR DESCRIPTION
## Summary
- silence E402 warnings by marking imports after sys.path modification
- run black/ruff on example scripts

## Testing
- `ruff check alita_agent_prototype/demo_working.py alita_agent_prototype/examples/basic_usage.py alita_agent_prototype/examples/gui_chat.py`
- `black --check alita_agent_prototype/demo_working.py alita_agent_prototype/examples/basic_usage.py alita_agent_prototype/examples/gui_chat.py`
- `pytest alita_agent_prototype/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7fa705130832894323307b06ca987